### PR TITLE
Dynamically load Windows DLL instead of link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ libloading = "0.8"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.36.1", features = ["Win32_Foundation", "Win32_Networking_WinSock"] }
-once_cell = "1.19"
+once_cell = { version = "1.19", optional = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # This really belongs in [dev-dependencies], but we can't have optional dev-deps
@@ -50,7 +50,7 @@ pkg-config = "0.3"
 capture-stream = ["tokio", "futures", "windows-sys/Win32_System_Threading"]
 tap-tests = ["tun-tap", "etherparse"]
 lending-iter = ["gat-std"]
-dynamic-load = []
+dynamic-load = ["once_cell"]
 # an empty feature to detect if '--all-features' was set
 all-features = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,11 @@ gat-std = { version = "0.1.1", optional = true }
 # and these libraries would truncate the min support Rust version (MSRV)
 tun-tap = { version = "0.1.3", optional = true }
 etherparse = { version = "0.13.0", optional = true }
+libloading = "0.8"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.36.1", features = ["Win32_Foundation", "Win32_Networking_WinSock"] }
+once_cell = "1.19"
 
 [dev-dependencies]
 tempdir = "0.3"
@@ -34,7 +36,7 @@ tempdir = "0.3"
 eui48 = "1.1"
 
 [build-dependencies]
-libloading = "0.6"
+libloading = "0.8"
 regex = "1"
 pkg-config = "0.3"
 
@@ -44,6 +46,7 @@ pkg-config = "0.3"
 capture-stream = ["tokio", "futures"]
 tap-tests = ["tun-tap", "etherparse"]
 lending-iter = ["gat-std"]
+dynamic-load = []
 # an empty feature to detect if '--all-features' was set
 all-features = []
 

--- a/build.rs
+++ b/build.rs
@@ -99,7 +99,7 @@ fn get_libpcap_version(libdirpath: Option<PathBuf>) -> Result<Version, Box<dyn s
         libfile = libdir.join(libfile);
     }
 
-    let lib = if let Ok(lib) = libloading::Library::new(libfile) {
+    let lib = if let Ok(lib) = unsafe { libloading::Library::new(libfile) } {
         lib
     } else {
         return Ok(Version::max());

--- a/src/dynamic_win_raw.rs
+++ b/src/dynamic_win_raw.rs
@@ -109,49 +109,49 @@ unsafe fn load_library() -> Library {
 }
 
 pub unsafe fn pcap_create(arg1: *const c_char, arg2: *mut c_char) -> *mut pcap_t {
-    let func = LIBRARY.get::<PcapCreate>(b"pcap_create").unwrap();
+    let func = LIBRARY.get::<PcapCreate>(b"pcap_create\0").unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_set_snaplen(arg1: *mut pcap_t, arg2: c_int) -> c_int {
-    let func = LIBRARY.get::<PcapSetSnaplen>(b"pcap_set_snaplen").unwrap();
+    let func = LIBRARY.get::<PcapSetSnaplen>(b"pcap_set_snaplen\0").unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_set_promisc(arg1: *mut pcap_t, arg2: c_int) -> c_int {
-    let func = LIBRARY.get::<PcapSetPromisc>(b"pcap_set_promisc").unwrap();
+    let func = LIBRARY.get::<PcapSetPromisc>(b"pcap_set_promisc\0").unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_set_timeout(arg1: *mut pcap_t, arg2: c_int) -> c_int {
-    let func = LIBRARY.get::<PcapSetTimeout>(b"pcap_set_timeout").unwrap();
+    let func = LIBRARY.get::<PcapSetTimeout>(b"pcap_set_timeout\0").unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_set_buffer_size(arg1: *mut pcap_t, arg2: c_int) -> c_int {
     let func = LIBRARY
-        .get::<PcapSetBufferSize>(b"pcap_set_buffer_size")
+        .get::<PcapSetBufferSize>(b"pcap_set_buffer_size\0")
         .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_activate(arg1: *mut pcap_t) -> c_int {
-    let func = LIBRARY.get::<PcapActivate>(b"pcap_activate").unwrap();
+    let func = LIBRARY.get::<PcapActivate>(b"pcap_activate\0").unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_open_dead(arg1: c_int, arg2: c_int) -> *mut pcap_t {
-    let func = LIBRARY.get::<PcapOpenDead>(b"pcap_open_dead").unwrap();
+    let func = LIBRARY.get::<PcapOpenDead>(b"pcap_open_dead\0").unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_open_offline(arg1: *const c_char, arg2: *mut c_char) -> *mut pcap_t {
     let func = LIBRARY
-        .get::<PcapOpenOffline>(b"pcap_open_offline")
+        .get::<PcapOpenOffline>(b"pcap_open_offline\0")
         .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_fopen_offline(arg1: *mut FILE, arg2: *mut c_char) -> *mut pcap_t {
     let func = LIBRARY
-        .get::<PcapFopenOffline>(b"pcap_fopen_offline")
+        .get::<PcapFopenOffline>(b"pcap_fopen_offline\0")
         .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_close(arg1: *mut pcap_t) {
-    let func = LIBRARY.get::<PcapClose>(b"pcap_close").unwrap();
+    let func = LIBRARY.get::<PcapClose>(b"pcap_close\0").unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_next_ex(
@@ -159,33 +159,33 @@ pub unsafe fn pcap_next_ex(
     arg2: *mut *mut pcap_pkthdr,
     arg3: *mut *const c_uchar,
 ) -> c_int {
-    let func = LIBRARY.get::<PcapNextEx>(b"pcap_next_ex").unwrap();
+    let func = LIBRARY.get::<PcapNextEx>(b"pcap_next_ex\0").unwrap();
     func(arg1, arg2, arg3)
 }
 pub unsafe fn pcap_stats(arg1: *mut pcap_t, arg2: *mut pcap_stat) -> c_int {
-    let func = LIBRARY.get::<PcapStats>(b"pcap_stats").unwrap();
+    let func = LIBRARY.get::<PcapStats>(b"pcap_stats\0").unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_setfilter(arg1: *mut pcap_t, arg2: *mut bpf_program) -> c_int {
-    let func = LIBRARY.get::<PcapSetfilter>(b"pcap_setfilter").unwrap();
+    let func = LIBRARY.get::<PcapSetfilter>(b"pcap_setfilter\0").unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_setdirection(arg1: *mut pcap_t, arg2: pcap_direction_t) -> c_int {
     let func = LIBRARY
-        .get::<PcapSetdirection>(b"pcap_setdirection")
+        .get::<PcapSetdirection>(b"pcap_setdirection\0")
         .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_setnonblock(arg1: *mut pcap_t, arg2: c_int, arg3: *mut c_char) -> c_int {
-    let func = LIBRARY.get::<PcapSetnonblock>(b"pcap_setnonblock").unwrap();
+    let func = LIBRARY.get::<PcapSetnonblock>(b"pcap_setnonblock\0").unwrap();
     func(arg1, arg2, arg3)
 }
 pub unsafe fn pcap_sendpacket(arg1: *mut pcap_t, arg2: *const c_uchar, arg3: c_int) -> c_int {
-    let func = LIBRARY.get::<PcapSendpacket>(b"pcap_sendpacket").unwrap();
+    let func = LIBRARY.get::<PcapSendpacket>(b"pcap_sendpacket\0").unwrap();
     func(arg1, arg2, arg3)
 }
 pub unsafe fn pcap_geterr(arg1: *mut pcap_t) -> *mut c_char {
-    let func = LIBRARY.get::<PcapGeterr>(b"pcap_geterr").unwrap();
+    let func = LIBRARY.get::<PcapGeterr>(b"pcap_geterr\0").unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_compile(
@@ -195,11 +195,11 @@ pub unsafe fn pcap_compile(
     arg4: c_int,
     arg5: c_uint,
 ) -> c_int {
-    let func = LIBRARY.get::<PcapCompile>(b"pcap_compile").unwrap();
+    let func = LIBRARY.get::<PcapCompile>(b"pcap_compile\0").unwrap();
     func(arg1, arg2, arg3, arg4, arg5)
 }
 pub unsafe fn pcap_freecode(arg1: *mut bpf_program) {
-    let func = LIBRARY.get::<PcapFreecode>(b"pcap_freecode").unwrap();
+    let func = LIBRARY.get::<PcapFreecode>(b"pcap_freecode\0").unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_offline_filter(
@@ -208,97 +208,97 @@ pub unsafe fn pcap_offline_filter(
     arg3: *const c_uchar,
 ) -> c_int {
     let func = LIBRARY
-        .get::<PcapOfflineFilter>(b"pcap_offline_filter")
+        .get::<PcapOfflineFilter>(b"pcap_offline_filter\0")
         .unwrap();
     func(arg1, arg2, arg3)
 }
 pub unsafe fn pcap_datalink(arg1: *mut pcap_t) -> c_int {
-    let func = LIBRARY.get::<PcapDatalink>(b"pcap_datalink").unwrap();
+    let func = LIBRARY.get::<PcapDatalink>(b"pcap_datalink\0").unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_list_datalinks(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c_int {
     let func = LIBRARY
-        .get::<PcapListDatalinks>(b"pcap_list_datalinks")
+        .get::<PcapListDatalinks>(b"pcap_list_datalinks\0")
         .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_set_datalink(arg1: *mut pcap_t, arg2: c_int) -> c_int {
     let func = LIBRARY
-        .get::<PcapSetDatalink>(b"pcap_set_datalink")
+        .get::<PcapSetDatalink>(b"pcap_set_datalink\0")
         .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_free_datalinks(arg1: *mut c_int) {
     let func = LIBRARY
-        .get::<PcapFreeDatalinks>(b"pcap_free_datalinks")
+        .get::<PcapFreeDatalinks>(b"pcap_free_datalinks\0")
         .unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_datalink_name_to_val(arg1: *const c_char) -> c_int {
     let func = LIBRARY
-        .get::<PcapDatalinkNameToVal>(b"pcap_datalink_name_to_val")
+        .get::<PcapDatalinkNameToVal>(b"pcap_datalink_name_to_val\0")
         .unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_datalink_val_to_name(arg1: c_int) -> *const c_char {
     let func = LIBRARY
-        .get::<PcapDatalinkValToName>(b"pcap_datalink_val_to_name")
+        .get::<PcapDatalinkValToName>(b"pcap_datalink_val_to_name\0")
         .unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_datalink_val_to_description(arg1: c_int) -> *const c_char {
     let func = LIBRARY
-        .get::<PcapDatalinkValToDescription>(b"pcap_datalink_val_to_description")
+        .get::<PcapDatalinkValToDescription>(b"pcap_datalink_val_to_description\0")
         .unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_major_version(arg1: *mut pcap_t) -> c_int {
     let func = LIBRARY
-        .get::<PcapMajorVersion>(b"pcap_major_version")
+        .get::<PcapMajorVersion>(b"pcap_major_version\0")
         .unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_minor_version(arg1: *mut pcap_t) -> c_int {
     let func = LIBRARY
-        .get::<PcapMinorVersion>(b"pcap_minor_version")
+        .get::<PcapMinorVersion>(b"pcap_minor_version\0")
         .unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_fileno(arg1: *mut pcap_t) -> c_int {
-    let func = LIBRARY.get::<PcapFileno>(b"pcap_fileno").unwrap();
+    let func = LIBRARY.get::<PcapFileno>(b"pcap_fileno\0").unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_dump_open(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t {
-    let func = LIBRARY.get::<PcapDumpOpen>(b"pcap_dump_open").unwrap();
+    let func = LIBRARY.get::<PcapDumpOpen>(b"pcap_dump_open\0").unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut FILE) -> *mut pcap_dumper_t {
-    let func = LIBRARY.get::<PcapDumpFopen>(b"pcap_dump_fopen").unwrap();
+    let func = LIBRARY.get::<PcapDumpFopen>(b"pcap_dump_fopen\0").unwrap();
     func(arg1, fp)
 }
 pub unsafe fn pcap_dump_flush(arg1: *mut pcap_dumper_t) -> c_int {
-    let func = LIBRARY.get::<PcapDumpFlush>(b"pcap_dump_flush").unwrap();
+    let func = LIBRARY.get::<PcapDumpFlush>(b"pcap_dump_flush\0").unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_dump_close(arg1: *mut pcap_dumper_t) {
-    let func = LIBRARY.get::<PcapDumpClose>(b"pcap_dump_close").unwrap();
+    let func = LIBRARY.get::<PcapDumpClose>(b"pcap_dump_close\0").unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_dump(arg1: *mut c_uchar, arg2: *const pcap_pkthdr, arg3: *const c_uchar) {
-    let func = LIBRARY.get::<PcapDump>(b"pcap_dump").unwrap();
+    let func = LIBRARY.get::<PcapDump>(b"pcap_dump\0").unwrap();
     func(arg1, arg2, arg3)
 }
 pub unsafe fn pcap_findalldevs(arg1: *mut *mut pcap_if_t, arg2: *mut c_char) -> c_int {
-    let func = LIBRARY.get::<PcapFindalldevs>(b"pcap_findalldevs").unwrap();
+    let func = LIBRARY.get::<PcapFindalldevs>(b"pcap_findalldevs\0").unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_freealldevs(arg1: *mut pcap_if_t) {
-    let func = LIBRARY.get::<PcapFreealldevs>(b"pcap_freealldevs").unwrap();
+    let func = LIBRARY.get::<PcapFreealldevs>(b"pcap_freealldevs\0").unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_get_selectable_fd(arg1: *mut pcap_t) -> c_int {
     let func = LIBRARY
-        .get::<PcapGetSelectableFd>(b"pcap_get_selectable_fd")
+        .get::<PcapGetSelectableFd>(b"pcap_get_selectable_fd\0")
         .unwrap();
     func(arg1)
 }
@@ -306,7 +306,7 @@ pub unsafe fn pcap_get_selectable_fd(arg1: *mut pcap_t) -> c_int {
 #[cfg(libpcap_1_2_1)]
 pub fn pcap_set_tstamp_type(arg1: *mut pcap_t, arg2: c_int) -> c_int {
     let func = LIBRARY
-        .get::<PcapSetTstampType>(b"pcap_set_tstamp_type")
+        .get::<PcapSetTstampType>(b"pcap_set_tstamp_type\0")
         .unwrap();
     func(arg1, arg2)
 }
@@ -318,14 +318,14 @@ pub fn pcap_fopen_offline_with_tstamp_precision(
     arg3: *mut c_char,
 ) -> *mut pcap_t {
     let func = LIBRARY
-        .get::<PcapFopenOfflineWithTstampPrecision>(b"pcap_fopen_offline_with_tstamp_precision")
+        .get::<PcapFopenOfflineWithTstampPrecision>(b"pcap_fopen_offline_with_tstamp_precision\0")
         .unwrap();
     func(arg1, arg2, arg3)
 }
 #[cfg(libpcap_1_5_0)]
 pub fn pcap_open_dead_with_tstamp_precision(arg1: c_int, arg2: c_int, arg3: c_uint) -> *mut pcap_t {
     let func = LIBRARY
-        .get::<PcapOpenDeadWithTstampPrecision>(b"pcap_open_dead_with_tstamp_precision")
+        .get::<PcapOpenDeadWithTstampPrecision>(b"pcap_open_dead_with_tstamp_precision\0")
         .unwrap();
     func(arg1, arg2, arg3)
 }
@@ -336,21 +336,21 @@ pub fn pcap_open_offline_with_tstamp_precision(
     arg3: *mut c_char,
 ) -> *mut pcap_t {
     let func = LIBRARY
-        .get::<PcapOpenOfflineWithTstampPrecision>(b"pcap_open_offline_with_tstamp_precision")
+        .get::<PcapOpenOfflineWithTstampPrecision>(b"pcap_open_offline_with_tstamp_precision\0")
         .unwrap();
     func(arg1, arg2, arg3)
 }
 #[cfg(libpcap_1_5_0)]
 pub fn pcap_set_immediate_mode(arg1: *mut pcap_t, arg2: c_int) -> c_int {
     let func = LIBRARY
-        .get::<PcapSetImmediateMode>(b"pcap_set_immediate_mode")
+        .get::<PcapSetImmediateMode>(b"pcap_set_immediate_mode\0")
         .unwrap();
     func(arg1, arg2)
 }
 #[cfg(libpcap_1_5_0)]
 pub fn pcap_set_tstamp_precision(arg1: *mut pcap_t, arg2: c_int) -> c_int {
     let func = LIBRARY
-        .get::<PcapSetTstampPrecision>(b"pcap_set_tstamp_precision")
+        .get::<PcapSetTstampPrecision>(b"pcap_set_tstamp_precision\0")
         .unwrap();
     func(arg1, arg2)
 }
@@ -358,30 +358,30 @@ pub fn pcap_set_tstamp_precision(arg1: *mut pcap_t, arg2: c_int) -> c_int {
 #[cfg(libpcap_1_7_2)]
 pub fn pcap_dump_open_append(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t {
     let func = LIBRARY
-        .get::<PcapDumpOpenAppend>(b"pcap_dump_open_append")
+        .get::<PcapDumpOpenAppend>(b"pcap_dump_open_append\0")
         .unwrap();
     func(arg1, arg2)
 }
 
 pub unsafe fn pcap_setmintocopy(arg1: *mut pcap_t, arg2: c_int) -> c_int {
     let func = LIBRARY
-        .get::<PcapSetmintocopy>(b"pcap_setmintocopy")
+        .get::<PcapSetmintocopy>(b"pcap_setmintocopy\0")
         .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_getevent(p: *mut pcap_t) -> HANDLE {
-    let func = LIBRARY.get::<PcapGetEvent>(b"pcap_getevent").unwrap();
+    let func = LIBRARY.get::<PcapGetEvent>(b"pcap_getevent\0").unwrap();
     func(p)
 }
 pub unsafe fn pcap_sendqueue_alloc(memsize: c_uint) -> *mut pcap_send_queue {
     let func = LIBRARY
-        .get::<PcapSendqueueAlloc>(b"pcap_sendqueue_alloc")
+        .get::<PcapSendqueueAlloc>(b"pcap_sendqueue_alloc\0")
         .unwrap();
     func(memsize)
 }
 pub unsafe fn pcap_sendqueue_destroy(queue: *mut pcap_send_queue) {
     let func = LIBRARY
-        .get::<PcapSendqueueDestroy>(b"pcap_sendqueue_destroy")
+        .get::<PcapSendqueueDestroy>(b"pcap_sendqueue_destroy\0")
         .unwrap();
     func(queue)
 }
@@ -391,7 +391,7 @@ pub unsafe fn pcap_sendqueue_queue(
     pkt_data: *const c_uchar,
 ) -> c_int {
     let func = LIBRARY
-        .get::<PcapSendqueueQueue>(b"pcap_sendqueue_queue")
+        .get::<PcapSendqueueQueue>(b"pcap_sendqueue_queue\0")
         .unwrap();
     func(queue, pkt_header, pkt_data)
 }
@@ -401,7 +401,7 @@ pub unsafe fn pcap_sendqueue_transmit(
     sync: c_int,
 ) -> c_uint {
     let func = LIBRARY
-        .get::<PcapSendqueueTransmit>(b"pcap_sendqueue_transmit")
+        .get::<PcapSendqueueTransmit>(b"pcap_sendqueue_transmit\0")
         .unwrap();
     func(p, queue, sync)
 }

--- a/src/dynamic_win_raw.rs
+++ b/src/dynamic_win_raw.rs
@@ -1,14 +1,14 @@
 #![allow(dead_code)]
 
-use std::env;
 use crate::raw_common::{
     bpf_program, pcap_direction_t, pcap_dumper_t, pcap_if_t, pcap_pkthdr, pcap_send_queue,
     pcap_stat, pcap_t,
 };
 use libc::{c_char, c_int, c_uchar, c_uint, FILE};
 use libloading::Library;
-use std::path::PathBuf;
 use once_cell::sync::Lazy;
+use std::env;
+use std::path::PathBuf;
 use windows_sys::Win32::Foundation::HANDLE;
 
 type PcapCreate = unsafe extern "C" fn(arg1: *const c_char, arg2: *mut c_char) -> *mut pcap_t;
@@ -90,9 +90,7 @@ type PcapSendqueueQueue = unsafe extern "C" fn(
 type PcapSendqueueTransmit =
     unsafe extern "C" fn(p: *mut pcap_t, queue: *mut pcap_send_queue, sync: c_int) -> c_uint;
 
-static mut LIBRARY: Lazy<Library> = Lazy::new(|| {
-    unsafe { load_library() }
-});
+static mut LIBRARY: Lazy<Library> = Lazy::new(|| unsafe { load_library() });
 
 unsafe fn load_library() -> Library {
     let mut libfile = PathBuf::from("wpcap.dll");
@@ -141,11 +139,15 @@ pub unsafe fn pcap_open_dead(arg1: c_int, arg2: c_int) -> *mut pcap_t {
     func(arg1, arg2)
 }
 pub unsafe fn pcap_open_offline(arg1: *const c_char, arg2: *mut c_char) -> *mut pcap_t {
-    let func = LIBRARY.get::<PcapOpenOffline>(b"pcap_open_offline").unwrap();
+    let func = LIBRARY
+        .get::<PcapOpenOffline>(b"pcap_open_offline")
+        .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_fopen_offline(arg1: *mut FILE, arg2: *mut c_char) -> *mut pcap_t {
-    let func = LIBRARY.get::<PcapFopenOffline>(b"pcap_fopen_offline").unwrap();
+    let func = LIBRARY
+        .get::<PcapFopenOffline>(b"pcap_fopen_offline")
+        .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_close(arg1: *mut pcap_t) {
@@ -169,7 +171,9 @@ pub unsafe fn pcap_setfilter(arg1: *mut pcap_t, arg2: *mut bpf_program) -> c_int
     func(arg1, arg2)
 }
 pub unsafe fn pcap_setdirection(arg1: *mut pcap_t, arg2: pcap_direction_t) -> c_int {
-    let func = LIBRARY.get::<PcapSetdirection>(b"pcap_setdirection").unwrap();
+    let func = LIBRARY
+        .get::<PcapSetdirection>(b"pcap_setdirection")
+        .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_setnonblock(arg1: *mut pcap_t, arg2: c_int, arg3: *mut c_char) -> c_int {
@@ -219,7 +223,9 @@ pub unsafe fn pcap_list_datalinks(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c
     func(arg1, arg2)
 }
 pub unsafe fn pcap_set_datalink(arg1: *mut pcap_t, arg2: c_int) -> c_int {
-    let func = LIBRARY.get::<PcapSetDatalink>(b"pcap_set_datalink").unwrap();
+    let func = LIBRARY
+        .get::<PcapSetDatalink>(b"pcap_set_datalink")
+        .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_free_datalinks(arg1: *mut c_int) {
@@ -247,11 +253,15 @@ pub unsafe fn pcap_datalink_val_to_description(arg1: c_int) -> *const c_char {
     func(arg1)
 }
 pub unsafe fn pcap_major_version(arg1: *mut pcap_t) -> c_int {
-    let func = LIBRARY.get::<PcapMajorVersion>(b"pcap_major_version").unwrap();
+    let func = LIBRARY
+        .get::<PcapMajorVersion>(b"pcap_major_version")
+        .unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_minor_version(arg1: *mut pcap_t) -> c_int {
-    let func = LIBRARY.get::<PcapMinorVersion>(b"pcap_minor_version").unwrap();
+    let func = LIBRARY
+        .get::<PcapMinorVersion>(b"pcap_minor_version")
+        .unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_fileno(arg1: *mut pcap_t) -> c_int {
@@ -354,7 +364,9 @@ pub fn pcap_dump_open_append(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pca
 }
 
 pub unsafe fn pcap_setmintocopy(arg1: *mut pcap_t, arg2: c_int) -> c_int {
-    let func = LIBRARY.get::<PcapSetmintocopy>(b"pcap_setmintocopy").unwrap();
+    let func = LIBRARY
+        .get::<PcapSetmintocopy>(b"pcap_setmintocopy")
+        .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_getevent(p: *mut pcap_t) -> HANDLE {

--- a/src/dynamic_win_raw.rs
+++ b/src/dynamic_win_raw.rs
@@ -113,15 +113,21 @@ pub unsafe fn pcap_create(arg1: *const c_char, arg2: *mut c_char) -> *mut pcap_t
     func(arg1, arg2)
 }
 pub unsafe fn pcap_set_snaplen(arg1: *mut pcap_t, arg2: c_int) -> c_int {
-    let func = LIBRARY.get::<PcapSetSnaplen>(b"pcap_set_snaplen\0").unwrap();
+    let func = LIBRARY
+        .get::<PcapSetSnaplen>(b"pcap_set_snaplen\0")
+        .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_set_promisc(arg1: *mut pcap_t, arg2: c_int) -> c_int {
-    let func = LIBRARY.get::<PcapSetPromisc>(b"pcap_set_promisc\0").unwrap();
+    let func = LIBRARY
+        .get::<PcapSetPromisc>(b"pcap_set_promisc\0")
+        .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_set_timeout(arg1: *mut pcap_t, arg2: c_int) -> c_int {
-    let func = LIBRARY.get::<PcapSetTimeout>(b"pcap_set_timeout\0").unwrap();
+    let func = LIBRARY
+        .get::<PcapSetTimeout>(b"pcap_set_timeout\0")
+        .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_set_buffer_size(arg1: *mut pcap_t, arg2: c_int) -> c_int {
@@ -177,7 +183,9 @@ pub unsafe fn pcap_setdirection(arg1: *mut pcap_t, arg2: pcap_direction_t) -> c_
     func(arg1, arg2)
 }
 pub unsafe fn pcap_setnonblock(arg1: *mut pcap_t, arg2: c_int, arg3: *mut c_char) -> c_int {
-    let func = LIBRARY.get::<PcapSetnonblock>(b"pcap_setnonblock\0").unwrap();
+    let func = LIBRARY
+        .get::<PcapSetnonblock>(b"pcap_setnonblock\0")
+        .unwrap();
     func(arg1, arg2, arg3)
 }
 pub unsafe fn pcap_sendpacket(arg1: *mut pcap_t, arg2: *const c_uchar, arg3: c_int) -> c_int {
@@ -289,11 +297,15 @@ pub unsafe fn pcap_dump(arg1: *mut c_uchar, arg2: *const pcap_pkthdr, arg3: *con
     func(arg1, arg2, arg3)
 }
 pub unsafe fn pcap_findalldevs(arg1: *mut *mut pcap_if_t, arg2: *mut c_char) -> c_int {
-    let func = LIBRARY.get::<PcapFindalldevs>(b"pcap_findalldevs\0").unwrap();
+    let func = LIBRARY
+        .get::<PcapFindalldevs>(b"pcap_findalldevs\0")
+        .unwrap();
     func(arg1, arg2)
 }
 pub unsafe fn pcap_freealldevs(arg1: *mut pcap_if_t) {
-    let func = LIBRARY.get::<PcapFreealldevs>(b"pcap_freealldevs\0").unwrap();
+    let func = LIBRARY
+        .get::<PcapFreealldevs>(b"pcap_freealldevs\0")
+        .unwrap();
     func(arg1)
 }
 pub unsafe fn pcap_get_selectable_fd(arg1: *mut pcap_t) -> c_int {

--- a/src/dynamic_win_raw.rs
+++ b/src/dynamic_win_raw.rs
@@ -1,0 +1,395 @@
+#![allow(dead_code)]
+
+use std::env;
+use crate::raw_common::{
+    bpf_program, pcap_direction_t, pcap_dumper_t, pcap_if_t, pcap_pkthdr, pcap_send_queue,
+    pcap_stat, pcap_t,
+};
+use libc::{c_char, c_int, c_uchar, c_uint, FILE};
+use libloading::Library;
+use std::path::PathBuf;
+use once_cell::sync::Lazy;
+use windows_sys::Win32::Foundation::HANDLE;
+
+type PcapCreate = unsafe extern "C" fn(arg1: *const c_char, arg2: *mut c_char) -> *mut pcap_t;
+type PcapSetSnaplen = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+type PcapSetPromisc = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+type PcapSetTimeout = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+type PcapSetBufferSize = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+type PcapActivate = unsafe extern "C" fn(arg1: *mut pcap_t) -> c_int;
+type PcapOpenDead = unsafe extern "C" fn(arg1: c_int, arg2: c_int) -> *mut pcap_t;
+type PcapOpenOffline = unsafe extern "C" fn(arg1: *const c_char, arg2: *mut c_char) -> *mut pcap_t;
+type PcapFopenOffline = unsafe extern "C" fn(arg1: *mut FILE, arg2: *mut c_char) -> *mut pcap_t;
+type PcapClose = unsafe extern "C" fn(arg1: *mut pcap_t);
+type PcapNextEx = unsafe extern "C" fn(
+    arg1: *mut pcap_t,
+    arg2: *mut *mut pcap_pkthdr,
+    arg3: *mut *const c_uchar,
+) -> c_int;
+type PcapStats = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: *mut pcap_stat) -> c_int;
+type PcapSetfilter = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: *mut bpf_program) -> c_int;
+type PcapSetdirection = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: pcap_direction_t) -> c_int;
+type PcapSetnonblock =
+    unsafe extern "C" fn(arg1: *mut pcap_t, arg2: c_int, arg3: *mut c_char) -> c_int;
+type PcapSendpacket =
+    unsafe extern "C" fn(arg1: *mut pcap_t, arg2: *const c_uchar, arg3: c_int) -> c_int;
+type PcapGeterr = unsafe extern "C" fn(arg1: *mut pcap_t) -> *mut c_char;
+type PcapCompile = unsafe extern "C" fn(
+    arg1: *mut pcap_t,
+    arg2: *mut bpf_program,
+    arg3: *const c_char,
+    arg4: c_int,
+    arg5: c_uint,
+) -> c_int;
+type PcapFreecode = unsafe extern "C" fn(arg1: *mut bpf_program);
+type PcapOfflineFilter = unsafe extern "C" fn(
+    arg1: *const bpf_program,
+    arg2: *const pcap_pkthdr,
+    arg3: *const c_uchar,
+) -> c_int;
+type PcapDatalink = unsafe extern "C" fn(arg1: *mut pcap_t) -> c_int;
+type PcapListDatalinks = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c_int;
+type PcapSetDatalink = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+type PcapFreeDatalinks = unsafe extern "C" fn(arg1: *mut c_int);
+type PcapDatalinkNameToVal = unsafe extern "C" fn(arg1: *const c_char) -> c_int;
+type PcapDatalinkValToName = unsafe extern "C" fn(arg1: c_int) -> *const c_char;
+type PcapDatalinkValToDescription = unsafe extern "C" fn(arg1: c_int) -> *const c_char;
+type PcapMajorVersion = unsafe extern "C" fn(arg1: *mut pcap_t) -> c_int;
+type PcapMinorVersion = unsafe extern "C" fn(arg1: *mut pcap_t) -> c_int;
+type PcapFileno = unsafe extern "C" fn(arg1: *mut pcap_t) -> c_int;
+type PcapDumpOpen =
+    unsafe extern "C" fn(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t;
+type PcapDumpFopen = unsafe extern "C" fn(arg1: *mut pcap_t, fp: *mut FILE) -> *mut pcap_dumper_t;
+type PcapDumpFlush = unsafe extern "C" fn(arg1: *mut pcap_dumper_t) -> c_int;
+type PcapDumpClose = unsafe extern "C" fn(arg1: *mut pcap_dumper_t);
+type PcapDump =
+    unsafe extern "C" fn(arg1: *mut c_uchar, arg2: *const pcap_pkthdr, arg3: *const c_uchar);
+type PcapFindalldevs = unsafe extern "C" fn(arg1: *mut *mut pcap_if_t, arg2: *mut c_char) -> c_int;
+type PcapFreealldevs = unsafe extern "C" fn(arg1: *mut pcap_if_t);
+type PcapGetSelectableFd = unsafe extern "C" fn(arg1: *mut pcap_t) -> c_int;
+type PcapSetTstampType = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+type PcapFopenOfflineWithTstampPrecision =
+    unsafe extern "C" fn(arg1: *mut FILE, arg2: c_uint, arg3: *mut c_char) -> *mut pcap_t;
+type PcapOpenDeadWithTstampPrecision =
+    unsafe extern "C" fn(arg1: c_int, arg2: c_int, arg3: c_uint) -> *mut pcap_t;
+type PcapOpenOfflineWithTstampPrecision =
+    unsafe extern "C" fn(arg1: *const c_char, arg2: c_uint, arg3: *mut c_char) -> *mut pcap_t;
+type PcapSetImmediateMode = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+type PcapSetTstampPrecision = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+type PcapDumpOpenAppend =
+    unsafe extern "C" fn(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t;
+type PcapSetmintocopy = unsafe extern "C" fn(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+type PcapGetEvent = unsafe extern "C" fn(p: *mut pcap_t) -> HANDLE;
+type PcapSendqueueAlloc = unsafe extern "C" fn(memsize: c_uint) -> *mut pcap_send_queue;
+type PcapSendqueueDestroy = unsafe extern "C" fn(queue: *mut pcap_send_queue);
+type PcapSendqueueQueue = unsafe extern "C" fn(
+    queue: *mut pcap_send_queue,
+    pkt_header: *const pcap_pkthdr,
+    pkt_data: *const c_uchar,
+) -> c_int;
+type PcapSendqueueTransmit =
+    unsafe extern "C" fn(p: *mut pcap_t, queue: *mut pcap_send_queue, sync: c_int) -> c_uint;
+
+static mut LIBRARY: Lazy<Library> = Lazy::new(|| {
+    unsafe { load_library() }
+});
+
+unsafe fn load_library() -> Library {
+    let mut libfile = PathBuf::from("wpcap.dll");
+
+    let libdirpath = if let Ok(libdir) = env::var("LIBPCAP_LIBDIR") {
+        Some(PathBuf::from(&libdir))
+    } else {
+        None
+    };
+
+    if let Some(libdir) = libdirpath {
+        libfile = libdir.join(libfile);
+    }
+
+    Library::new(libfile).unwrap()
+}
+
+pub unsafe fn pcap_create(arg1: *const c_char, arg2: *mut c_char) -> *mut pcap_t {
+    let func = LIBRARY.get::<PcapCreate>(b"pcap_create").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_set_snaplen(arg1: *mut pcap_t, arg2: c_int) -> c_int {
+    let func = LIBRARY.get::<PcapSetSnaplen>(b"pcap_set_snaplen").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_set_promisc(arg1: *mut pcap_t, arg2: c_int) -> c_int {
+    let func = LIBRARY.get::<PcapSetPromisc>(b"pcap_set_promisc").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_set_timeout(arg1: *mut pcap_t, arg2: c_int) -> c_int {
+    let func = LIBRARY.get::<PcapSetTimeout>(b"pcap_set_timeout").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_set_buffer_size(arg1: *mut pcap_t, arg2: c_int) -> c_int {
+    let func = LIBRARY
+        .get::<PcapSetBufferSize>(b"pcap_set_buffer_size")
+        .unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_activate(arg1: *mut pcap_t) -> c_int {
+    let func = LIBRARY.get::<PcapActivate>(b"pcap_activate").unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_open_dead(arg1: c_int, arg2: c_int) -> *mut pcap_t {
+    let func = LIBRARY.get::<PcapOpenDead>(b"pcap_open_dead").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_open_offline(arg1: *const c_char, arg2: *mut c_char) -> *mut pcap_t {
+    let func = LIBRARY.get::<PcapOpenOffline>(b"pcap_open_offline").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_fopen_offline(arg1: *mut FILE, arg2: *mut c_char) -> *mut pcap_t {
+    let func = LIBRARY.get::<PcapFopenOffline>(b"pcap_fopen_offline").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_close(arg1: *mut pcap_t) {
+    let func = LIBRARY.get::<PcapClose>(b"pcap_close").unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_next_ex(
+    arg1: *mut pcap_t,
+    arg2: *mut *mut pcap_pkthdr,
+    arg3: *mut *const c_uchar,
+) -> c_int {
+    let func = LIBRARY.get::<PcapNextEx>(b"pcap_next_ex").unwrap();
+    func(arg1, arg2, arg3)
+}
+pub unsafe fn pcap_stats(arg1: *mut pcap_t, arg2: *mut pcap_stat) -> c_int {
+    let func = LIBRARY.get::<PcapStats>(b"pcap_stats").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_setfilter(arg1: *mut pcap_t, arg2: *mut bpf_program) -> c_int {
+    let func = LIBRARY.get::<PcapSetfilter>(b"pcap_setfilter").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_setdirection(arg1: *mut pcap_t, arg2: pcap_direction_t) -> c_int {
+    let func = LIBRARY.get::<PcapSetdirection>(b"pcap_setdirection").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_setnonblock(arg1: *mut pcap_t, arg2: c_int, arg3: *mut c_char) -> c_int {
+    let func = LIBRARY.get::<PcapSetnonblock>(b"pcap_setnonblock").unwrap();
+    func(arg1, arg2, arg3)
+}
+pub unsafe fn pcap_sendpacket(arg1: *mut pcap_t, arg2: *const c_uchar, arg3: c_int) -> c_int {
+    let func = LIBRARY.get::<PcapSendpacket>(b"pcap_sendpacket").unwrap();
+    func(arg1, arg2, arg3)
+}
+pub unsafe fn pcap_geterr(arg1: *mut pcap_t) -> *mut c_char {
+    let func = LIBRARY.get::<PcapGeterr>(b"pcap_geterr").unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_compile(
+    arg1: *mut pcap_t,
+    arg2: *mut bpf_program,
+    arg3: *const c_char,
+    arg4: c_int,
+    arg5: c_uint,
+) -> c_int {
+    let func = LIBRARY.get::<PcapCompile>(b"pcap_compile").unwrap();
+    func(arg1, arg2, arg3, arg4, arg5)
+}
+pub unsafe fn pcap_freecode(arg1: *mut bpf_program) {
+    let func = LIBRARY.get::<PcapFreecode>(b"pcap_freecode").unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_offline_filter(
+    arg1: *const bpf_program,
+    arg2: *const pcap_pkthdr,
+    arg3: *const c_uchar,
+) -> c_int {
+    let func = LIBRARY
+        .get::<PcapOfflineFilter>(b"pcap_offline_filter")
+        .unwrap();
+    func(arg1, arg2, arg3)
+}
+pub unsafe fn pcap_datalink(arg1: *mut pcap_t) -> c_int {
+    let func = LIBRARY.get::<PcapDatalink>(b"pcap_datalink").unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_list_datalinks(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c_int {
+    let func = LIBRARY
+        .get::<PcapListDatalinks>(b"pcap_list_datalinks")
+        .unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_set_datalink(arg1: *mut pcap_t, arg2: c_int) -> c_int {
+    let func = LIBRARY.get::<PcapSetDatalink>(b"pcap_set_datalink").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_free_datalinks(arg1: *mut c_int) {
+    let func = LIBRARY
+        .get::<PcapFreeDatalinks>(b"pcap_free_datalinks")
+        .unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_datalink_name_to_val(arg1: *const c_char) -> c_int {
+    let func = LIBRARY
+        .get::<PcapDatalinkNameToVal>(b"pcap_datalink_name_to_val")
+        .unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_datalink_val_to_name(arg1: c_int) -> *const c_char {
+    let func = LIBRARY
+        .get::<PcapDatalinkValToName>(b"pcap_datalink_val_to_name")
+        .unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_datalink_val_to_description(arg1: c_int) -> *const c_char {
+    let func = LIBRARY
+        .get::<PcapDatalinkValToDescription>(b"pcap_datalink_val_to_description")
+        .unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_major_version(arg1: *mut pcap_t) -> c_int {
+    let func = LIBRARY.get::<PcapMajorVersion>(b"pcap_major_version").unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_minor_version(arg1: *mut pcap_t) -> c_int {
+    let func = LIBRARY.get::<PcapMinorVersion>(b"pcap_minor_version").unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_fileno(arg1: *mut pcap_t) -> c_int {
+    let func = LIBRARY.get::<PcapFileno>(b"pcap_fileno").unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_dump_open(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t {
+    let func = LIBRARY.get::<PcapDumpOpen>(b"pcap_dump_open").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut FILE) -> *mut pcap_dumper_t {
+    let func = LIBRARY.get::<PcapDumpFopen>(b"pcap_dump_fopen").unwrap();
+    func(arg1, fp)
+}
+pub unsafe fn pcap_dump_flush(arg1: *mut pcap_dumper_t) -> c_int {
+    let func = LIBRARY.get::<PcapDumpFlush>(b"pcap_dump_flush").unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_dump_close(arg1: *mut pcap_dumper_t) {
+    let func = LIBRARY.get::<PcapDumpClose>(b"pcap_dump_close").unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_dump(arg1: *mut c_uchar, arg2: *const pcap_pkthdr, arg3: *const c_uchar) {
+    let func = LIBRARY.get::<PcapDump>(b"pcap_dump").unwrap();
+    func(arg1, arg2, arg3)
+}
+pub unsafe fn pcap_findalldevs(arg1: *mut *mut pcap_if_t, arg2: *mut c_char) -> c_int {
+    let func = LIBRARY.get::<PcapFindalldevs>(b"pcap_findalldevs").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_freealldevs(arg1: *mut pcap_if_t) {
+    let func = LIBRARY.get::<PcapFreealldevs>(b"pcap_freealldevs").unwrap();
+    func(arg1)
+}
+pub unsafe fn pcap_get_selectable_fd(arg1: *mut pcap_t) -> c_int {
+    let func = LIBRARY
+        .get::<PcapGetSelectableFd>(b"pcap_get_selectable_fd")
+        .unwrap();
+    func(arg1)
+}
+
+#[cfg(libpcap_1_2_1)]
+pub fn pcap_set_tstamp_type(arg1: *mut pcap_t, arg2: c_int) -> c_int {
+    let func = LIBRARY
+        .get::<PcapSetTstampType>(b"pcap_set_tstamp_type")
+        .unwrap();
+    func(arg1, arg2)
+}
+
+#[cfg(libpcap_1_5_0)]
+pub fn pcap_fopen_offline_with_tstamp_precision(
+    arg1: *mut FILE,
+    arg2: c_uint,
+    arg3: *mut c_char,
+) -> *mut pcap_t {
+    let func = LIBRARY
+        .get::<PcapFopenOfflineWithTstampPrecision>(b"pcap_fopen_offline_with_tstamp_precision")
+        .unwrap();
+    func(arg1, arg2, arg3)
+}
+#[cfg(libpcap_1_5_0)]
+pub fn pcap_open_dead_with_tstamp_precision(arg1: c_int, arg2: c_int, arg3: c_uint) -> *mut pcap_t {
+    let func = LIBRARY
+        .get::<PcapOpenDeadWithTstampPrecision>(b"pcap_open_dead_with_tstamp_precision")
+        .unwrap();
+    func(arg1, arg2, arg3)
+}
+#[cfg(libpcap_1_5_0)]
+pub fn pcap_open_offline_with_tstamp_precision(
+    arg1: *const c_char,
+    arg2: c_uint,
+    arg3: *mut c_char,
+) -> *mut pcap_t {
+    let func = LIBRARY
+        .get::<PcapOpenOfflineWithTstampPrecision>(b"pcap_open_offline_with_tstamp_precision")
+        .unwrap();
+    func(arg1, arg2, arg3)
+}
+#[cfg(libpcap_1_5_0)]
+pub fn pcap_set_immediate_mode(arg1: *mut pcap_t, arg2: c_int) -> c_int {
+    let func = LIBRARY
+        .get::<PcapSetImmediateMode>(b"pcap_set_immediate_mode")
+        .unwrap();
+    func(arg1, arg2)
+}
+#[cfg(libpcap_1_5_0)]
+pub fn pcap_set_tstamp_precision(arg1: *mut pcap_t, arg2: c_int) -> c_int {
+    let func = LIBRARY
+        .get::<PcapSetTstampPrecision>(b"pcap_set_tstamp_precision")
+        .unwrap();
+    func(arg1, arg2)
+}
+
+#[cfg(libpcap_1_7_2)]
+pub fn pcap_dump_open_append(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t {
+    let func = LIBRARY
+        .get::<PcapDumpOpenAppend>(b"pcap_dump_open_append")
+        .unwrap();
+    func(arg1, arg2)
+}
+
+pub unsafe fn pcap_setmintocopy(arg1: *mut pcap_t, arg2: c_int) -> c_int {
+    let func = LIBRARY.get::<PcapSetmintocopy>(b"pcap_setmintocopy").unwrap();
+    func(arg1, arg2)
+}
+pub unsafe fn pcap_getevent(p: *mut pcap_t) -> HANDLE {
+    let func = LIBRARY.get::<PcapGetEvent>(b"pcap_getevent").unwrap();
+    func(p)
+}
+pub unsafe fn pcap_sendqueue_alloc(memsize: c_uint) -> *mut pcap_send_queue {
+    let func = LIBRARY
+        .get::<PcapSendqueueAlloc>(b"pcap_sendqueue_alloc")
+        .unwrap();
+    func(memsize)
+}
+pub unsafe fn pcap_sendqueue_destroy(queue: *mut pcap_send_queue) {
+    let func = LIBRARY
+        .get::<PcapSendqueueDestroy>(b"pcap_sendqueue_destroy")
+        .unwrap();
+    func(queue)
+}
+pub unsafe fn pcap_sendqueue_queue(
+    queue: *mut pcap_send_queue,
+    pkt_header: *const pcap_pkthdr,
+    pkt_data: *const c_uchar,
+) -> c_int {
+    let func = LIBRARY
+        .get::<PcapSendqueueQueue>(b"pcap_sendqueue_queue")
+        .unwrap();
+    func(queue, pkt_header, pkt_data)
+}
+pub unsafe fn pcap_sendqueue_transmit(
+    p: *mut pcap_t,
+    queue: *mut pcap_send_queue,
+    sync: c_int,
+) -> c_uint {
+    let func = LIBRARY
+        .get::<PcapSendqueueTransmit>(b"pcap_sendqueue_transmit")
+        .unwrap();
+    func(p, queue, sync)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ mod raw;
 mod raw_common;
 #[cfg(all(target_os = "windows", feature = "dynamic-load"))]
 use dynamic_win_raw as raw;
+#[cfg(windows)]
 pub mod sendqueue;
 #[cfg(feature = "capture-stream")]
 #[cfg_attr(windows, path = "stream_windows.rs")]
@@ -1193,7 +1194,7 @@ impl<T: Activated + ?Sized> Capture<T> {
     #[cfg(not(windows))]
     pub unsafe fn savefile_raw_fd(&self, fd: RawFd) -> Result<Savefile, Error> {
         open_raw_fd(fd, b'w').and_then(|file| {
-            let handle_opt = NonNull::<raw::pcap_dumper_t>::new(raw::pcap_dump_fopen(
+            let handle_opt = NonNull::<raw_common::pcap_dumper_t>::new(raw::pcap_dump_fopen(
                 self.handle.as_ptr(),
                 file,
             ));
@@ -1213,7 +1214,7 @@ impl<T: Activated + ?Sized> Capture<T> {
     #[cfg(libpcap_1_7_2)]
     pub fn savefile_append<P: AsRef<Path>>(&self, path: P) -> Result<Savefile, Error> {
         let name = CString::new(path.as_ref().to_str().unwrap())?;
-        let handle_opt = NonNull::<raw::pcap_dumper_t>::new(unsafe {
+        let handle_opt = NonNull::<raw_common::pcap_dumper_t>::new(unsafe {
             raw::pcap_dump_open_append(self.handle.as_ptr(), name.as_ptr())
         });
         let handle = self
@@ -1368,7 +1369,7 @@ impl Capture<Dead> {
             raw::pcap_open_dead_with_tstamp_precision(linktype.0, 65535, precision as u32)
         };
         Ok(Capture::from(
-            NonNull::<raw::pcap_t>::new(handle).ok_or(InsufficientMemory)?,
+            NonNull::<raw_common::pcap_t>::new(handle).ok_or(InsufficientMemory)?,
         ))
     }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -2,9 +2,10 @@
 
 use libc::{c_char, c_int, c_uchar, c_uint, FILE};
 
+#[cfg(windows)]
+use crate::raw_common::pcap_send_queue;
 use crate::raw_common::{
-    bpf_program, pcap_direction_t, pcap_dumper_t, pcap_if_t, pcap_pkthdr, pcap_send_queue,
-    pcap_stat, pcap_t,
+    bpf_program, pcap_direction_t, pcap_dumper_t, pcap_if_t, pcap_pkthdr, pcap_stat, pcap_t,
 };
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::HANDLE;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,106 +1,13 @@
 #![allow(dead_code)]
-#![allow(non_camel_case_types)]
 
-use libc::{c_char, c_int, c_uchar, c_uint, c_ushort, sockaddr, timeval, FILE};
+use libc::{c_char, c_int, c_uchar, c_uint, FILE};
 
+use crate::raw_common::{
+    bpf_program, pcap_direction_t, pcap_dumper_t, pcap_if_t, pcap_pkthdr, pcap_send_queue,
+    pcap_stat, pcap_t,
+};
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::HANDLE;
-
-pub const PCAP_IF_LOOPBACK: u32 = 0x00000001;
-pub const PCAP_IF_UP: u32 = 0x00000002;
-pub const PCAP_IF_RUNNING: u32 = 0x00000004;
-pub const PCAP_IF_WIRELESS: u32 = 0x00000008;
-pub const PCAP_IF_CONNECTION_STATUS: u32 = 0x00000030;
-pub const PCAP_IF_CONNECTION_STATUS_UNKNOWN: u32 = 0x00000000;
-pub const PCAP_IF_CONNECTION_STATUS_CONNECTED: u32 = 0x00000010;
-pub const PCAP_IF_CONNECTION_STATUS_DISCONNECTED: u32 = 0x00000020;
-pub const PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE: u32 = 0x00000030;
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct bpf_program {
-    pub bf_len: c_uint,
-    pub bf_insns: *mut bpf_insn,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct bpf_insn {
-    pub code: c_ushort,
-    pub jt: c_uchar,
-    pub jf: c_uchar,
-    pub k: c_uint,
-}
-
-pub enum pcap_t {}
-
-pub enum pcap_dumper_t {}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct pcap_file_header {
-    pub magic: c_uint,
-    pub version_major: c_ushort,
-    pub version_minor: c_ushort,
-    pub thiszone: c_int,
-    pub sigfigs: c_uint,
-    pub snaplen: c_uint,
-    pub linktype: c_uint,
-}
-
-pub type pcap_direction_t = c_uint;
-
-pub const PCAP_D_INOUT: pcap_direction_t = 0;
-pub const PCAP_D_IN: pcap_direction_t = 1;
-pub const PCAP_D_OUT: pcap_direction_t = 2;
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct pcap_pkthdr {
-    pub ts: timeval,
-    pub caplen: c_uint,
-    pub len: c_uint,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct pcap_stat {
-    pub ps_recv: c_uint,
-    pub ps_drop: c_uint,
-    pub ps_ifdrop: c_uint,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct pcap_if_t {
-    pub next: *mut pcap_if_t,
-    pub name: *mut c_char,
-    pub description: *mut c_char,
-    pub addresses: *mut pcap_addr_t,
-    pub flags: c_uint,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct pcap_addr_t {
-    pub next: *mut pcap_addr_t,
-    pub addr: *mut sockaddr,
-    pub netmask: *mut sockaddr,
-    pub broadaddr: *mut sockaddr,
-    pub dstaddr: *mut sockaddr,
-}
-
-#[cfg(windows)]
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct pcap_send_queue {
-    pub maxlen: c_uint,
-    pub len: c_uint,
-    pub buffer: *mut c_char,
-}
-
-pub type pcap_handler =
-    Option<extern "C" fn(arg1: *mut c_uchar, arg2: *const pcap_pkthdr, arg3: *const c_uchar) -> ()>;
 
 extern "C" {
     // [OBSOLETE] pub fn pcap_lookupdev(arg1: *mut c_char) -> *mut c_char;
@@ -242,9 +149,6 @@ extern "C" {
 extern "C" {
     // pcap_datalink_val_to_description_or_dlt
 }
-
-#[cfg(windows)]
-pub const WINPCAP_MINTOCOPY_DEFAULT: c_int = 16000;
 
 #[cfg(windows)]
 #[link(name = "wpcap")]

--- a/src/raw_common.rs
+++ b/src/raw_common.rs
@@ -1,0 +1,99 @@
+#![allow(non_camel_case_types)]
+
+use libc::{c_char, c_int, c_uchar, c_uint, c_ushort, sockaddr, timeval};
+
+pub const PCAP_IF_LOOPBACK: u32 = 0x00000001;
+pub const PCAP_IF_UP: u32 = 0x00000002;
+pub const PCAP_IF_RUNNING: u32 = 0x00000004;
+pub const PCAP_IF_WIRELESS: u32 = 0x00000008;
+pub const PCAP_IF_CONNECTION_STATUS: u32 = 0x00000030;
+pub const PCAP_IF_CONNECTION_STATUS_UNKNOWN: u32 = 0x00000000;
+pub const PCAP_IF_CONNECTION_STATUS_CONNECTED: u32 = 0x00000010;
+pub const PCAP_IF_CONNECTION_STATUS_DISCONNECTED: u32 = 0x00000020;
+pub const PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE: u32 = 0x00000030;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct bpf_program {
+    pub bf_len: c_uint,
+    pub bf_insns: *mut bpf_insn,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct bpf_insn {
+    pub code: c_ushort,
+    pub jt: c_uchar,
+    pub jf: c_uchar,
+    pub k: c_uint,
+}
+
+pub enum pcap_t {}
+
+pub enum pcap_dumper_t {}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct pcap_file_header {
+    pub magic: c_uint,
+    pub version_major: c_ushort,
+    pub version_minor: c_ushort,
+    pub thiszone: c_int,
+    pub sigfigs: c_uint,
+    pub snaplen: c_uint,
+    pub linktype: c_uint,
+}
+
+pub type pcap_direction_t = c_uint;
+
+pub const PCAP_D_INOUT: pcap_direction_t = 0;
+pub const PCAP_D_IN: pcap_direction_t = 1;
+pub const PCAP_D_OUT: pcap_direction_t = 2;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct pcap_pkthdr {
+    pub ts: timeval,
+    pub caplen: c_uint,
+    pub len: c_uint,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct pcap_stat {
+    pub ps_recv: c_uint,
+    pub ps_drop: c_uint,
+    pub ps_ifdrop: c_uint,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct pcap_if_t {
+    pub next: *mut pcap_if_t,
+    pub name: *mut c_char,
+    pub description: *mut c_char,
+    pub addresses: *mut pcap_addr_t,
+    pub flags: c_uint,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct pcap_addr_t {
+    pub next: *mut pcap_addr_t,
+    pub addr: *mut sockaddr,
+    pub netmask: *mut sockaddr,
+    pub broadaddr: *mut sockaddr,
+    pub dstaddr: *mut sockaddr,
+}
+
+#[cfg(windows)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct pcap_send_queue {
+    pub maxlen: c_uint,
+    pub len: c_uint,
+    pub buffer: *mut c_char,
+}
+
+#[cfg(windows)]
+pub const WINPCAP_MINTOCOPY_DEFAULT: c_int = 16000;

--- a/src/sendqueue.rs
+++ b/src/sendqueue.rs
@@ -10,10 +10,11 @@ use std::io::IoSlice;
 use std::ptr::NonNull;
 
 use crate::raw;
+use crate::raw_common;
 use crate::Error;
 use crate::{Active, Capture};
 
-pub struct SendQueue(NonNull<raw::pcap_send_queue>);
+pub struct SendQueue(NonNull<raw_common::pcap_send_queue>);
 
 pub enum SendSync {
     Off = 0,
@@ -21,8 +22,8 @@ pub enum SendSync {
 }
 
 #[inline]
-fn make_pkthdr(ts: Option<std::time::Duration>, len: u32) -> raw::pcap_pkthdr {
-    raw::pcap_pkthdr {
+fn make_pkthdr(ts: Option<std::time::Duration>, len: u32) -> raw_common::pcap_pkthdr {
+    raw_common::pcap_pkthdr {
         ts: if let Some(ts) = ts {
             libc::timeval {
                 // tv_sec is currently i32 in libc when building for Windows
@@ -112,7 +113,7 @@ impl SendQueue {
         // Note: It is assumed that len cannot exceed maxlen.  This invariant must be upheld by
         // all methods implemented by SendQueue.
         let remain = (self.maxlen() - self.len()) as usize;
-        let need = std::mem::size_of::<raw::pcap_pkthdr>() + pktsize;
+        let need = std::mem::size_of::<raw_common::pcap_pkthdr>() + pktsize;
         if remain < need {
             return Err(Error::BufferOverflow);
         }
@@ -134,7 +135,7 @@ impl SendQueue {
         let mut wbuf = unsafe { sqbuf.offset(bufoffs) };
 
         // Copy packet header into the sendqueue's buffer
-        let mut lastlen = std::mem::size_of::<raw::pcap_pkthdr>();
+        let mut lastlen = std::mem::size_of::<raw_common::pcap_pkthdr>();
         unsafe {
             std::ptr::copy_nonoverlapping(rawhdr, wbuf, lastlen);
         }


### PR DESCRIPTION
To allow programs to dynamically choose if it needs to load/if it can load the pcap dependencies, we created a feature flag to use libloading to load in the DLL at runtime, instead of being linked to it.

Tested against no driver, Winpcap driver, Npcap driver